### PR TITLE
Adding two new shortcuts for highlight and striketrough

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
       {
         "command": "typst-companion.extension.editing.toggleStriketrough",
         "key": "ctrl+shift+u",
-        "mac": "cmd+shifht+u",
+        "mac": "cmd+shift+u",
         "when": "editorTextFocus && !editorReadonly && editorLangId == typst"
       },
       {

--- a/package.json
+++ b/package.json
@@ -172,6 +172,18 @@
         "when": "editorTextFocus && !editorReadonly && editorLangId == typst"
       },
       {
+        "command": "typst-companion.extension.editing.toggleHighlight",
+        "key": "ctrl+h",
+        "mac": "cmd+h",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == typst"
+      },
+      {
+        "command": "typst-companion.extension.editing.toggleStriketrough",
+        "key": "ctrl+shift+u",
+        "mac": "cmd+shifht+u",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == typst"
+      },
+      {
         "command": "typst-companion.extension.editing.toggleHeadingUp",
         "key": "ctrl+shift+]",
         "mac": "ctrl+shift+]",

--- a/src/format.ts
+++ b/src/format.ts
@@ -54,11 +54,11 @@ function toggleUnderline() {
 }
 
 function toggleHighlight() {
-    return styleByWrapping("highlight[", "]");
+    return styleByWrapping("#highlight[", "]");
 }
 
 function toggleStriketrough() {
-    return styleByWrapping("strike[", "]");
+    return styleByWrapping("#strike[", "]");
 }
 
 async function toggleHeadingUp() {

--- a/src/format.ts
+++ b/src/format.ts
@@ -33,6 +33,8 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand('typst-companion.extension.editing.toggleBold', toggleBold),
         commands.registerCommand('typst-companion.extension.editing.toggleItalic', toggleItalic),
         commands.registerCommand('typst-companion.extension.editing.toggleUnderline', toggleUnderline),
+        commands.registerCommand('typst-companion.extension.editing.toggleHighlight', toggleHighlight),
+        commands.registerCommand('typst-companion.extension.editing.toggleStriketrough', toggleStriketrough),
         commands.registerCommand('typst-companion.extension.editing.toggleHeadingUp', toggleHeadingUp),
         commands.registerCommand('typst-companion.extension.editing.toggleHeadingDown', toggleHeadingDown),
         commands.registerCommand('typst-companion.extension.editing.toggleList', toggleList)
@@ -49,6 +51,14 @@ function toggleBold() {
 
 function toggleUnderline() {
     return styleByWrapping("#underline[", "]");
+}
+
+function toggleHighlight() {
+    return styleByWrapping("highlight[", "]");
+}
+
+function toggleStriketrough() {
+    return styleByWrapping("strike[", "]");
 }
 
 async function toggleHeadingUp() {


### PR DESCRIPTION
toggleStriketrough => https://typst.app/docs/reference/text/strike/
toggleHighlight => https://typst.app/docs/reference/text/highlight/